### PR TITLE
Append to file for thermodynamic_state and parrinello_rahman

### DIFF
--- a/src/io/dump_thermodynamic_state.cpp
+++ b/src/io/dump_thermodynamic_state.cpp
@@ -25,6 +25,7 @@ namespace exaStamp
     ADD_SLOT( double             , electronic_energy   , INPUT, OPTIONAL );
     ADD_SLOT( std::string        , file                , INPUT , "thermodynamic_state.csv" );
     ADD_SLOT( bool               , force_flush_file    , INPUT , false );
+    ADD_SLOT( bool               , force_append_thermo , INPUT , false );    
     ADD_SLOT( bool               , is_dump_virial      , INPUT , false);
     // NEW
     ADD_SLOT(Domain              , domain              , INPUT , OPTIONAL, DocString{"Deformation box matrix"} );
@@ -115,7 +116,7 @@ namespace exaStamp
       }
       oss << "\n";
 
-      FileAppendWriteBuffer::instance().append_to_file( *file , oss.str() );
+      FileAppendWriteBuffer::instance().append_to_file( *file , oss.str(), *force_append_thermo );
 
       if( *force_flush_file )
       {

--- a/src/io/dump_thermodynamic_state_rigidmol.cpp
+++ b/src/io/dump_thermodynamic_state_rigidmol.cpp
@@ -24,7 +24,8 @@ namespace exaStamp
     ADD_SLOT( double             , electronic_energy   , INPUT, OPTIONAL );
     ADD_SLOT( std::string        , file                , INPUT , "thermodynamic_state.csv" );
     ADD_SLOT( bool               , force_flush_file    , INPUT , false );
-
+    ADD_SLOT( bool               , force_append_thermo , INPUT , false );
+    
     inline void execute () override final
     {
       static const double conv_temperature = 1.e4 * legacy_constant::atomicMass / legacy_constant::boltzmann ;
@@ -83,7 +84,7 @@ namespace exaStamp
       
       oss << "\n";
 
-      FileAppendWriteBuffer::instance().append_to_file( *file , oss.str() );
+      FileAppendWriteBuffer::instance().append_to_file( *file , oss.str(), *force_append_thermo );
 
       if( *force_flush_file )
       {

--- a/src/parrinellorahman/update_xform_parrinellorahman.cpp
+++ b/src/parrinellorahman/update_xform_parrinellorahman.cpp
@@ -34,6 +34,7 @@ namespace exaStamp
     ADD_SLOT( std::string             , file       , INPUT , "parrinello_rahman.dat" );
     ADD_SLOT( long                    , timestep            , INPUT, REQUIRED);
     ADD_SLOT( double                  , physical_time       , INPUT );
+    ADD_SLOT( bool                    , force_append_thermo , INPUT , false );
 
     using PointerTuple = onika::soatl::FieldPointerTuple< GridT::CellParticles::Alignment , GridT::CellParticles::ChunkSize, field::_vx, field::_vy, field::_vz >;
 
@@ -100,7 +101,7 @@ namespace exaStamp
 			   newMat.m32,
 			   newMat.m33);
 
-      FileAppendWriteBuffer::instance().append_to_file( *file , oss.str() );
+      FileAppendWriteBuffer::instance().append_to_file( *file , oss.str(), *force_append_thermo);
 
       //const Mat3d newPM = parrinello_rahman_ctx->h * diag_matrix( reciprocal(newExt) );
       //ldbg << "newPM = "<< newPM << std::endl;


### PR DESCRIPTION
Dump thermo state for general and rigidmol as well as parrinello rahman allow to append to .csv file if it exists and if user asks for it.
In line with small modification made in exaNBody, already integrated in main branch of exaNBody.