### PR TITLE
fixes compiler warnings and compatibility issues with Cuda code (std:…

### DIFF
--- a/include/exaStamp/atom_bond_connectivity.h
+++ b/include/exaStamp/atom_bond_connectivity.h
@@ -17,7 +17,7 @@ under the License.
 
 #pragma once
 
-#include <array>
+#include <onika/oarray.h>
 #include <cstdint>
 #include <iostream>
 #include <limits>
@@ -26,6 +26,6 @@ namespace exaStamp
 {  
 
   // an atom can have up to 4 chemical bonds
-  using AtomBondConnectivity = std::array<uint64_t,4>;
+  using AtomBondConnectivity = onika::oarray_t<uint64_t,4>;
 }
 

--- a/src/io/tests/stampv3_to_lammps.cpp
+++ b/src/io/tests/stampv3_to_lammps.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
     std::cout << "Energie rotationnelle  = " << header.rotationalEnergy << std::endl;
     std::cout << " --------------------------------------------"<<std::endl;
     
-    double *tmp_x, *tmp_y, *tmp_z, *tmp_dx, *tmp_dy, *tmp_dz;
+    double *tmp_x, *tmp_y, *tmp_z; // double *tmp_dx, *tmp_dy, *tmp_dz;
     uint64_t *tmp_id;
 
     scale = 1E9;
@@ -117,9 +117,9 @@ int main(int argc, char** argv)
     tmp_x = new double[N];
     tmp_y = new double[N];
     tmp_z = new double[N];
-    tmp_dx = new double[N];
-    tmp_dy = new double[N];
-    tmp_dz = new double[N];
+    // tmp_dx = new double[N];
+    // tmp_dy = new double[N];
+    // tmp_dz = new double[N];
     tmp_id = new uint64_t[N];
 
     int n = header.particlesTotalNumber;

--- a/src/io/tests/xyz2legacy.cpp
+++ b/src/io/tests/xyz2legacy.cpp
@@ -42,14 +42,14 @@ int main (int argc, char *argv[])
   std::cout << "Converting " << inputFile << " to " << filename << " ..." << std::endl;
 
   LegacyHeaderIOStruct entete ;
-  LegacyParticleIOStruct uneParticule;
+  // LegacyParticleIOStruct uneParticule;
   LegacyParticleIOStruct *particlesArray;
    
-  int rank, size, count, i;
+  int rank, size, count; // int i;
   long PaticleID;
   double x,y,z;
   std::string UneLigne;
-  char unType[100],unMot[100];
+  char unType[100]; // char unMot[100];
   char uneTabDeMots[5][100];
   double uneTableDeDouble[20];
 

--- a/src/molecule/include/exaStamp/molecule/extract_connectivity.h
+++ b/src/molecule/include/exaStamp/molecule/extract_connectivity.h
@@ -393,7 +393,7 @@ namespace exaStamp
         for(size_t p=0; p<n_particles; ++p)
         {
           uint64_t p_id = ids[p];
-          const std::array<uint64_t, 4>& neigh = cmols[p];
+          const auto& neigh = cmols[p];
           
           if( cell_is_here )
           {

--- a/src/molecule/include/exaStamp/molecule/potential_functional.h
+++ b/src/molecule/include/exaStamp/molecule/potential_functional.h
@@ -110,6 +110,7 @@ namespace exaStamp
              + energy_offset               
              };
     }
+    return { 0. , 0. };
   }
 
   // base definition for an intra molecular potential. might also be used as a null potential

--- a/src/molecule/include/exaStamp/molecule/read_stamp_v4.h
+++ b/src/molecule/include/exaStamp/molecule/read_stamp_v4.h
@@ -601,7 +601,7 @@ namespace exaStamp
       uint64_t molnum = 0;
       unsigned int moltype = 0;
       //unsigned int molplace = 0;
-      std::array<uint64_t,4> cmol = { 0, 0, 0, 0 };
+      AtomBondConnectivity cmol = { 0, 0, 0, 0 };
 
       if( entete->bloc_molecules )
       {
@@ -611,7 +611,7 @@ namespace exaStamp
         mol_id = molnum + ( uint64_t(moltype) << 48 );
 
         //atom connectivity : note, ids are INT in stamp, not UINT.
-        cmol = std::array<uint64_t,4>{static_cast<uint64_t>(molecules[i].Connectivite[0]),
+        cmol = AtomBondConnectivity{static_cast<uint64_t>(molecules[i].Connectivite[0]),
                                       static_cast<uint64_t>(molecules[i].Connectivite[1]),
                                       static_cast<uint64_t>(molecules[i].Connectivite[2]),
                                       static_cast<uint64_t>(molecules[i].Connectivite[3])};

--- a/src/molecule/intramolecular_pair_list.cpp
+++ b/src/molecule/intramolecular_pair_list.cpp
@@ -137,7 +137,7 @@ namespace exaStamp
           decode_cell_particle( chemical_pair[0], c, p, ta );
           decode_cell_particle( chemical_pair[1], c, p, tb );
           const int pair_id = unique_pair_id(ta,tb);
-          const auto & potparm = molecule_compute_parameters->m_pair_params[ n_type_pairs * chemicalLinkType + pair_id ];
+          // const auto & potparm = molecule_compute_parameters->m_pair_params[ n_type_pairs * chemicalLinkType + pair_id ];
           int param_idx = -1;
           // Since weight is only applied on the Coulombic part of RF, we still need that parameters set to be considered
           param_idx = n_type_pairs * chemicalLinkType + pair_id ;

--- a/src/molecule/intramolecular_setup.cpp
+++ b/src/molecule/intramolecular_setup.cpp
@@ -321,7 +321,7 @@ namespace exaStamp
       // To access the info easily, we construct locally the reverse map, ffnameToFFtypeId
       std::map< std::string , int64_t > ffnameToFFtypeId;
       if (ffnameVector.has_value()) {
-        for (int iFF = 0; iFF < ffnameVector->size(); iFF++) {
+        for (size_t iFF = 0; iFF < ffnameVector->size(); iFF++) {
           ffnameToFFtypeId[ ffnameVector->at(iFF) ] = iFF;
         }
       }

--- a/src/molecule/read_fatomes_mol.cpp
+++ b/src/molecule/read_fatomes_mol.cpp
@@ -470,11 +470,12 @@ namespace exaStamp
 	      {
 	        ffnameVector->at( ffpair.second ) = ffpair.first;
 	      }
+#       ifndef NDEBUG
 	      for(const auto & ffname : *ffnameVector)
 	      {
 	        assert( ! ffname.empty() );
 	      }
-	
+#       endif
 
         // read file until section "PositionDesAtomes" and fill all variables corresponding to the sections "TypeAtomes" and "Potentiel" read before
         while( atom_pos_unit.empty() )
@@ -683,7 +684,7 @@ namespace exaStamp
           }
           charge = species->at(itypeAtom).m_charge;
 
-          MoleculeTupleIO tp( r.x, r.y, r.z , 0.0, 0.0, 0.0, at_id, itypeAtom, 0, std::array<uint64_t,4>{uint64_t(-1),uint64_t(-1),uint64_t(-1),uint64_t(-1)} , charge );
+          MoleculeTupleIO tp( r.x, r.y, r.z , 0.0, 0.0, 0.0, at_id, itypeAtom, 0, AtomBondConnectivity{uint64_t(-1),uint64_t(-1),uint64_t(-1),uint64_t(-1)} , charge );
           atom_data.push_back( tp );     
         }
         ldbg << "file bbox = " << file_bbox << " , size = " << ( file_bbox.bmax - file_bbox.bmin ) << std::endl;       

--- a/src/molecule/read_xyz_molecules.cpp
+++ b/src/molecule/read_xyz_molecules.cpp
@@ -217,7 +217,7 @@ namespace exaStamp
           const int itypeAtom = type_name_to_index(typeAtom);
 
           const Vec3d v = { 0., 0., 0. }; // not read from file by now
-          MoleculeTupleIO tp( r.x, r.y, r.z , v.x, v.y, v.z, at_id, itypeAtom, 0, std::array<uint64_t,4>{uint64_t(c0),uint64_t(c1),uint64_t(c2),uint64_t(c3)} , charge );
+          MoleculeTupleIO tp( r.x, r.y, r.z , v.x, v.y, v.z, at_id, itypeAtom, 0, AtomBondConnectivity{uint64_t(c0),uint64_t(c1),uint64_t(c2),uint64_t(c3)} , charge );
           atom_data.push_back( tp );     
         }
         file.close();

--- a/src/potential/igar/include/igar_force_from_gradient.h
+++ b/src/potential/igar/include/igar_force_from_gradient.h
@@ -183,9 +183,9 @@ namespace exaStamp
       }
 #endif
 
-      const IJK dims = grid.dimension();
-      const ssize_t gl = grid.ghost_layers();
-      const IJK dims_no_gl = dims - 2 * gl;
+      // const IJK dims = grid.dimension();
+      // const ssize_t gl = grid.ghost_layers();
+      // const IJK dims_no_gl = dims - 2 * gl;
       const double cell_size = grid.cell_size();
       const double subcell_size = cell_size / subdiv;
       const double inv_subcell_size = 1.0 / subcell_size;

--- a/src/potential/igar/include/igar_force_interp.h
+++ b/src/potential/igar/include/igar_force_interp.h
@@ -149,7 +149,7 @@ namespace exaStamp
 
       const GridCellField &e_field = grid_cell_values.field(e_name);
       const ssize_t subdiv = static_cast<ssize_t>(e_field.m_subdiv);
-      const ssize_t subcell_count = subdiv * subdiv * subdiv;
+      // const ssize_t subcell_count = subdiv * subdiv * subdiv;
 
       const double cell_size = grid.cell_size();
       const double subcell_size = cell_size / subdiv;

--- a/src/potential/rebo/include/rebo_force_op_cached.h
+++ b/src/potential/rebo/include/rebo_force_op_cached.h
@@ -349,7 +349,7 @@ namespace exaStamp
                            int type, Mat3dT& virial, double nC_central, double nH_central, double Nconj_central, CellParticlesT cells,
                            GridCellLocksT locks, ParticleLockT& lock_a) const
     {
-      static constexpr bool   vflag = std::is_same_v<Mat3dT, Mat3d>;
+      // static constexpr bool   vflag = std::is_same_v<Mat3dT, Mat3d>;
       static constexpr double TOL   = 1.0e-9;
       static constexpr double thmin = -1.0;
       static constexpr double thmax = -0.995;
@@ -467,9 +467,9 @@ namespace exaStamp
           if (kk == jj) continue;
           const int    ktype = buf.ext.type[kk];
           const double rik   = rebo_r[kpos];
-          double dS;
+          // double dS;
           const double wik = rebo_w[kpos];
-          dS = rebo_dw[kpos];
+          // dS = rebo_dw[kpos];
           // lambda (nonzero only when i is H)
           const double lam = (itype==1)
             ? 4.0*((p.rho[ktype][1]-rik) - (p.rho[jtype][1]-rij)) : 0.0;

--- a/src/potential/rebo/include/rebo_params.h
+++ b/src/potential/rebo/include/rebo_params.h
@@ -301,11 +301,11 @@ namespace exaStamp
       // Temporary knot-value arrays (all zero-initialised)
       // -----------------------------------------------------------------------
       double PCCf[5][5]         = {};
-      double PCCdfdx[5][5]      = {};
-      double PCCdfdy[5][5]      = {};
+      // double PCCdfdx[5][5]      = {};
+      // double PCCdfdy[5][5]      = {};
       double PCHf[5][5]         = {};
-      double PCHdfdx[5][5]      = {};
-      double PCHdfdy[5][5]      = {};
+      // double PCHdfdx[5][5]      = {};
+      // double PCHdfdy[5][5]      = {};
       double piCCf[5][5][11]    = {};
       double piCCdfdx[5][5][11] = {};
       double piCCdfdy[5][5][11] = {};

--- a/src/potential/rebo/rebo.cu
+++ b/src/potential/rebo/rebo.cu
@@ -86,10 +86,10 @@ namespace exaStamp
       assert( chunk_neighbors->number_of_cells() == grid->number_of_cells() );
       if ( grid->number_of_cells() == 0 ) return;
 
-      bool eflag = false;
+      // bool eflag = false;
       if (trigger_thermo_state.has_value()) {
         ldbg << "trigger_thermo_state = " << *trigger_thermo_state << std::endl;
-        eflag = *trigger_thermo_state;
+        // eflag = *trigger_thermo_state;
       }
 
       // Read Only Rebo parameters
@@ -98,7 +98,7 @@ namespace exaStamp
       // ------------------------------------------------------------------------------ //
       // First pass: we compute NijC and NijH bond order per atom
       // ------------------------------------------------------------------------------ //
-      ComputePairOptionalLocks<false> cp_locks {};
+      // ComputePairOptionalLocks<false> cp_locks {};
       exanb::GridChunkNeighborsLightWeightIt<false> nbh_it{ *chunk_neighbors };
       // auto compute_buf_bondorder = make_compute_pair_buffer<ComputeBufferBondOrder>();     
       // Accessor for NijC and NijH

--- a/src/rigidmol/random_orient.cpp
+++ b/src/rigidmol/random_orient.cpp
@@ -46,8 +46,8 @@ namespace exaStamp
       IJK dims = grid->dimension();
       ssize_t gl = grid->ghost_layers();      
       IJK gstart { gl, gl, gl };
-      IJK gend = dims - IJK{ gl, gl, gl };
-      IJK gdims = gend - gstart;
+      // IJK gend = dims - IJK{ gl, gl, gl };
+      // IJK gdims = gend - gstart;
       const auto dom_dims = domain->grid_dimension();
       const auto dom_start = grid->offset();
 


### PR DESCRIPTION
…:array cannot be used inside device code, hence cmol must be and onika::oarray_t<uint64_t,4> and not a std::array<uint64_t,4>